### PR TITLE
Improve `make install` for Linux

### DIFF
--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -48,6 +48,14 @@ DEBUG ?= 0
 
 CC ?= gcc
 LINKER = $(CC)
+INSTALL = install -v
+INSTALL_PROGRAM = $(INSTALL) -m755
+INSTALL_DATA = $(INSTALL) -m644
+
+PREFIX = /usr/local
+BINDIR = $(PREFIX)/bin
+DATAROOTDIR = $(PREFIX)/share
+DATADIR = $(DATAROOTDIR)
 
 STRIP ?= strip
 PKG_CONFIG ?= pkg-config
@@ -317,8 +325,12 @@ install:	sprawl96
 	cp sprawl96.pak $(IW_APP_DIR)
 else
 install:	sprawl96
-	cp sprawl96 /usr/local/games/quake
-	cp sprawl96.pak /usr/local/games/quake
+	mkdir -p $(BINDIR) $(DATADIR)/games/quake/ $(DATADIR)/applications/ $(DATADIR)/icons/hicolor/scalable/apps/ $(DATADIR)/metainfo/
+	$(INSTALL_PROGRAM) -D sprawl96 -t $(BINDIR)/
+	$(INSTALL_DATA) -D sprawl96.pak $(DATADIR)/games/quake/
+	$(INSTALL_PROGRAM) ../Linux/gg.sprawl.sprawl96.desktop $(DATADIR)/applications/gg.sprawl.sprawl96.desktop
+	$(INSTALL_DATA) ../Linux/gg.sprawl.sprawl96.svg $(DATADIR)/icons/hicolor/scalable/apps/
+	$(INSTALL_DATA) ../Linux/gg.sprawl.sprawl96.metainfo.xml $(DATADIR)/metainfo/gg.sprawl.sprawl96.metainfo.xml
 endif
 
 #---------------------------------------------------------------


### PR DESCRIPTION
This will:

- install not just the game executable and pak file but also the `.desktop` launcher, icon and metadata
- allow overriding the default installation destination with the `PREFIX` variable

These changes are useful for the Flatpak build, as they'll simplify the work needed in the actual build process there. ;)