### PR TITLE
Fix flathub listing quality warnings and clarify licensing

### DIFF
--- a/Linux/gg.sprawl.sprawl96.metainfo.xml
+++ b/Linux/gg.sprawl.sprawl96.metainfo.xml
@@ -11,7 +11,7 @@
     <color type="primary" scheme_preference="light">#e4b983</color>
     <color type="primary" scheme_preference="dark">#1c2e5a</color>
   </branding>
-  <summary>A Quake mod based on the retro shooter SPRAWL</summary>
+  <summary>A cyberpunk retro shooter Quake mod</summary>
   <icon type="remote">https://cdn.jsdelivr.net/gh/VoidForce/QSprawl/Misc/gg.sprawl.sprawl96.svg</icon>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0-only</project_license>

--- a/Linux/gg.sprawl.sprawl96.metainfo.xml
+++ b/Linux/gg.sprawl.sprawl96.metainfo.xml
@@ -7,6 +7,10 @@
     <name>Carlos "REVEL" Lizarraga, Hannah "EMBYR" Crawford, VoidForce, SPRAWL 96 contributors</name>
     <url>https://github.com/VoidForce/QSprawl/graphs/contributors</url>
   </developer>
+  <branding>
+    <color type="primary" scheme_preference="light">#e4b983</color>
+    <color type="primary" scheme_preference="dark">#1c2e5a</color>
+  </branding>
   <summary>A Quake mod based on the retro shooter SPRAWL</summary>
   <icon type="remote">https://cdn.jsdelivr.net/gh/VoidForce/QSprawl/Misc/gg.sprawl.sprawl96.svg</icon>
   <metadata_license>CC0-1.0</metadata_license>

--- a/Linux/gg.sprawl.sprawl96.metainfo.xml
+++ b/Linux/gg.sprawl.sprawl96.metainfo.xml
@@ -11,9 +11,8 @@
     <color type="primary" scheme_preference="dark">#1c2e5a</color>
   </branding>
   <summary>Cyberpunk retro shooter Quake mod</summary>
-  <icon type="remote">https://cdn.jsdelivr.net/gh/VoidForce/QSprawl/Misc/gg.sprawl.sprawl96.svg</icon>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-2.0-only</project_license>
+  <project_license>GPL-2.0-only AND CC-BY-NC-SA-4.0 AND BSD-3-Clause</project_license>
   <launchable type="desktop-id">gg.sprawl.sprawl96.desktop</launchable>
   <url type="homepage">https://www.slipseer.com/index.php?resources/sprawl-96.398/</url>
   <url type="contact">https://discord.gg/4kVen5XDfn</url>
@@ -22,6 +21,12 @@
     <p>SPRAWL was originally built on the Darkplaces Quake engine, and the resources provided by nearly 30 years of dedicated modders made it possible to get it started.</p>
     <p>It's a revival in a sense of that original Quake engine version of SPRAWL. It answers the question “What if SPRAWL actually existed in 1996?”. So it includes every single SPRAWL weapon (sorta), some enemies, and our movement all on a custom fork of the Ironwail source port.</p>
     <p>By default, SPRAWL will install the LibreQuake content pack so it can be played even without having Quake itself, but you can add custom maps and replace LibreQuake with your normal Quake installation if you so wish.</p>
+    <p>Licenses:</p>
+    <ul>
+      <li>QSprawl engine code: GPL 2.0</li>
+      <li>LibreQuake base assets: BSD 3-Clause</li>
+      <li>SPRAWL 96 assets: CC BY-NC-SA 4.0 International</li>
+    </ul>
   </description>
   <screenshots>
     <screenshot type="default">
@@ -69,9 +74,6 @@
     <keyword>total conversion</keyword>
   </keywords>
   <releases>
-    <release version="1.2" date="2024-12-27">
-      <description>v1.2	includes a number of bug fixes to the engine and four new maps created by contributors as part of the SPRAWL 96 map jam!</description>
-    </release>
     <release version="1.1" date="2024-09-16">
       <description>v1.1 adds support for Copper maps</description>
     </release>

--- a/Linux/gg.sprawl.sprawl96.metainfo.xml
+++ b/Linux/gg.sprawl.sprawl96.metainfo.xml
@@ -77,7 +77,7 @@
     <release version="1.2" date="2024-12-27">
       <description>v1.2	includes a number of bug fixes to the engine and four new maps created by contributors as part of the SPRAWL 96 map jam!</description>
     </release>
-	<release version="1.1" date="2024-09-16">
+    <release version="1.1" date="2024-09-16">
       <description>v1.1 adds support for Copper maps</description>
     </release>
     <release version="1.0" date="2024-08-23">

--- a/Linux/gg.sprawl.sprawl96.metainfo.xml
+++ b/Linux/gg.sprawl.sprawl96.metainfo.xml
@@ -28,7 +28,7 @@
 		add custom maps by copying them to <code>$HOME/.var/app/io.github.voidforce.qsprawl/data/sprawl/maps/</code>.</p>
     <p>Licenses:</p>
     <ul>
-      <li>QSprawl engine code: GPL 2.0</li>
+      <li>QSprawl engine code and QuakeC game logic: GPL 2.0</li>
       <li>LibreQuake base assets: BSD 3-Clause</li>
       <li>SPRAWL 96 assets: CC BY-NC-SA 4.0 International</li>
     </ul>

--- a/Linux/gg.sprawl.sprawl96.metainfo.xml
+++ b/Linux/gg.sprawl.sprawl96.metainfo.xml
@@ -17,10 +17,15 @@
   <url type="homepage">https://www.slipseer.com/index.php?resources/sprawl-96.398/</url>
   <url type="contact">https://discord.gg/4kVen5XDfn</url>
   <description>
-    <p>SPRAWL 96 is a celebration of our retro shooter SPRAWL, released for the first anniversary of SPRAWL's release. It’s also our way of giving thanks and giving back to the communities which made SPRAWL possible.</p>
-    <p>SPRAWL was originally built on the Darkplaces Quake engine, and the resources provided by nearly 30 years of dedicated modders made it possible to get it started.</p>
-    <p>It's a revival in a sense of that original Quake engine version of SPRAWL. It answers the question “What if SPRAWL actually existed in 1996?”. So it includes every single SPRAWL weapon (sorta), some enemies, and our movement all on a custom fork of the Ironwail source port.</p>
-    <p>By default, SPRAWL will install the LibreQuake content pack so it can be played even without having Quake itself, but you can add custom maps and replace LibreQuake with your normal Quake installation if you so wish.</p>
+    <p>SPRAWL 96 is a celebration of our retro shooter SPRAWL, released for the first anniversary of SPRAWL's release. It’s
+		also our way of giving thanks and giving back to the communities which made SPRAWL possible.</p>
+    <p>SPRAWL was originally built on the Darkplaces Quake engine, and the resources provided by nearly 30 years of dedicated
+		modders made it possible to get it started.</p>
+    <p>It's a revival in a sense of that original Quake engine version of SPRAWL. It answers the question "What if SPRAWL
+		actually existed in 1996?". So it includes every single SPRAWL weapon (sorta), some enemies, and our movement all
+		on a custom fork of the Ironwail source port.</p>
+    <p>By default, SPRAWL includes LibreQuake content pack so it can be played even without having Quake itself. You can
+		add custom maps by copying them to <code>$HOME/.var/app/io.github.voidforce.qsprawl/data/sprawl/maps/</code>.</p>
     <p>Licenses:</p>
     <ul>
       <li>QSprawl engine code: GPL 2.0</li>

--- a/Linux/gg.sprawl.sprawl96.metainfo.xml
+++ b/Linux/gg.sprawl.sprawl96.metainfo.xml
@@ -11,7 +11,7 @@
     <color type="primary" scheme_preference="light">#e4b983</color>
     <color type="primary" scheme_preference="dark">#1c2e5a</color>
   </branding>
-  <summary>A cyberpunk retro shooter Quake mod</summary>
+  <summary>Cyberpunk retro shooter Quake mod</summary>
   <icon type="remote">https://cdn.jsdelivr.net/gh/VoidForce/QSprawl/Misc/gg.sprawl.sprawl96.svg</icon>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0-only</project_license>

--- a/Linux/gg.sprawl.sprawl96.metainfo.xml
+++ b/Linux/gg.sprawl.sprawl96.metainfo.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="https://cdn.jsdelivr.net/gh/fpiesche/flatpak-builds/_templates/app_page.xsl" ?>
 <component type="desktop-application">
   <id>gg.sprawl.sprawl96</id>
   <name>SPRAWL 96</name>

--- a/Linux/gg.sprawl.sprawl96.metainfo.xml
+++ b/Linux/gg.sprawl.sprawl96.metainfo.xml
@@ -74,7 +74,10 @@
     <keyword>total conversion</keyword>
   </keywords>
   <releases>
-    <release version="1.1" date="2024-09-16">
+    <release version="1.2" date="2024-12-27">
+      <description>v1.2	includes a number of bug fixes to the engine and four new maps created by contributors as part of the SPRAWL 96 map jam!</description>
+    </release>
+	<release version="1.1" date="2024-09-16">
       <description>v1.1 adds support for Copper maps</description>
     </release>
     <release version="1.0" date="2024-08-23">


### PR DESCRIPTION
Flathub flags a handful of warnings about the metadata:

- the summary is over 35 characters long
- there were no branding colours specified which can be used for eg. listing page backgrounds
- the remote icon URL was wrong, and Flathub strongly recommend against using remote icons

Neither of these are requirements but they're flagged as quality issues. The branding colours are taken from averages of some of the daytime/nighttime skyboxes.